### PR TITLE
feat: `range` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Example: Load all stable versions greater than `v1.2.1` but not inclusive.
 const releases = await octokit.getSemanticReleases({
   owner: "octokit",
   repo: "core.js",
-  range: ">v1.2.1",
+  range: ">1.2.1",
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,22 +117,22 @@ function myPlugin(octokit, options) {
     </tr>
     <tr>
       <th>
-        <code>since</code>
+        <code>range</code>
       </th>
       <th>
         <code>string</code>
       </th>
       <td>
 
-Filter out versions equal or lower than a provided `since` version.
+Filter out versions that don't match the `range` string following [semver conventions](https://semver.npmjs.com/).
 
-Example: Load all versions greater than `v1.2.3`
+Example: Load all stable versions greater than `v1.2.1` but not inclusive.
 
 ```js
 const releases = await octokit.getSemanticReleases({
   owner: "octokit",
   repo: "core.js",
-  since: "1.2.3",
+  range: ">v1.2.1",
 });
 ```
 

--- a/src/compose-get-semantic-releases.ts
+++ b/src/compose-get-semantic-releases.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "@octokit/core";
 import { composePaginateRest } from "@octokit/plugin-paginate-rest";
 import semverValid from "semver/functions/valid";
-import semverSatisfies from "semver/functions/satisfies"
+import semverSatisfies from "semver/functions/satisfies";
 import semverCompare from "semver/functions/compare";
 
 import { GetSemanticReleasesOptions } from "./types";
@@ -33,7 +33,8 @@ export async function composeGetSemanticReleases(
       if (!options.range) return { version, ...release };
 
       // If `range` is specified, return only releases that match the semver range
-      if (semverSatisfies(version, options.range)) return { version, ...release };
+      if (semverSatisfies(version, options.range))
+        return { version, ...release };
     })
     .filter(Boolean)
     .sort((releaseA, releaseB) =>

--- a/src/compose-get-semantic-releases.ts
+++ b/src/compose-get-semantic-releases.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "@octokit/core";
 import { composePaginateRest } from "@octokit/plugin-paginate-rest";
 import semverValid from "semver/functions/valid";
-import semverGt from "semver/functions/gt";
+import semverSatisfies from "semver/functions/satisfies"
 import semverCompare from "semver/functions/compare";
 
 import { GetSemanticReleasesOptions } from "./types";
@@ -29,11 +29,11 @@ export async function composeGetSemanticReleases(
       // Ignore non-semantic tags
       if (!semverValid(version)) return;
 
-      // If `since` is not specified, return all releases
-      if (!options.since) return { version, ...release };
+      // If `range` is not specified, return all releases
+      if (!options.range) return { version, ...release };
 
-      // If `since` is specified, return only releases newer than `since`
-      if (semverGt(version, options.since)) return { version, ...release };
+      // If `range` is specified, return only releases that match the semver range
+      if (semverSatisfies(version, options.range)) return { version, ...release };
     })
     .filter(Boolean)
     .sort((releaseA, releaseB) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type GetSemanticReleasesOptions = {
   owner: string;
   repo: string;
-  since?: string;
+  range?: string;
 };

--- a/test/get-semantic-releases.test.ts
+++ b/test/get-semantic-releases.test.ts
@@ -56,7 +56,7 @@ describe("octokit.getSemanticReleases()", () => {
     ]);
   });
 
-  it("since", async () => {
+  it("range", async () => {
     const mock = fetchMock
       .sandbox()
       .get("https://api.github.com/repos/octokit/core.js/releases", [
@@ -65,6 +65,12 @@ describe("octokit.getSemanticReleases()", () => {
         },
         {
           tag_name: "v1.0.1",
+        },
+        {
+          tag_name: "v1.0.3",
+        },
+        {
+          tag_name: "v1.0.3-debug.1",
         },
         {
           tag_name: "v1.1.0",
@@ -80,13 +86,46 @@ describe("octokit.getSemanticReleases()", () => {
       },
     });
 
-    const releases = await octokit.getSemanticReleases({
+    const exclusiveReleases = await octokit.getSemanticReleases({
       owner: "octokit",
       repo: "core.js",
-      since: "1.0.1",
+      range: ">1.0.1",
     });
 
-    expect(releases).toStrictEqual([
+    expect(exclusiveReleases).toStrictEqual([
+      {
+        version: "1.0.3",
+        tag_name: "v1.0.3",
+      },
+      {
+        version: "1.1.0",
+        tag_name: "v1.1.0",
+      },
+      {
+        version: "1.1.1",
+        tag_name: "v1.1.1",
+      },
+    ]);
+
+    const inclusiveReleases = await octokit.getSemanticReleases({
+      owner: "octokit",
+      repo: "core.js",
+      range: ">=1.0.1 || 1.0.3-debug.1",
+    });
+
+    expect(inclusiveReleases).toStrictEqual([
+      {
+        version: "1.0.1",
+        tag_name: "v1.0.1",
+      },
+      {
+        version: "1.0.3-debug.1",
+        tag_name: "v1.0.3-debug.1",
+      },
+      {
+        version: "1.0.3",
+        tag_name: "v1.0.3",
+      },
       {
         version: "1.1.0",
         tag_name: "v1.1.0",


### PR DESCRIPTION
Closes https://github.com/gr2m/octokit-plugin-get-semantic-releases/issues/6

### Breaking changes

- removes `since` option. Use `range` instead.